### PR TITLE
Add a pydantic model which encapsulates required BMI time meta data

### DIFF
--- a/bmi_pytorch/bmi_pytorch/bmi_model.py
+++ b/bmi_pytorch/bmi_pytorch/bmi_model.py
@@ -11,8 +11,10 @@ from .model import Model
 
 from typing import Tuple, List
 
+
 class UnknownBMIVariable(RuntimeError):
     pass
+
 
 class Bmi_Model(Bmi_Minimal):
     """BMI composition wrapper for Model
@@ -54,8 +56,7 @@ class Bmi_Model(Bmi_Minimal):
         self.optimizer = torch.optim.SGD(self.model.parameters(), self.learning_rate)
 
     def update(self):
-        """Update the model for the internal timestep duration
-        """
+        """Update the model for the internal timestep duration"""
         self.output = self.model(self.input)
 
     def finalize(self):
@@ -77,7 +78,7 @@ class Bmi_Model(Bmi_Minimal):
             int: number of input variables
         """
         return len(self.input_names)
-    
+
     def get_input_var_names(self) -> Tuple[str, ...]:
         """The names of each input variables
 
@@ -93,7 +94,7 @@ class Bmi_Model(Bmi_Minimal):
             int: number of output variables
         """
         return len(self.output_names)
-    
+
     def get_output_var_names(self) -> Tuple[str, ...]:
         """The names of each output variable
 
@@ -111,12 +112,14 @@ class Bmi_Model(Bmi_Minimal):
         np_array = self._values[name].numpy()
         shape = np_array.shape
         try:
-            #see if raveling is possible without a copy
+            # see if raveling is possible without a copy
             np_array.shape = (-1,)
-            #reset original shape
+            # reset original shape
             np_array.shape = shape
         except ValueError as e:
-            raise RuntimeError("Cannot flatten array without copying -- "+str(e).split(": ")[-1])
+            raise RuntimeError(
+                "Cannot flatten array without copying -- " + str(e).split(": ")[-1]
+            )
         return np_array.ravel()
 
     # BMI Variable Information Functions
@@ -133,9 +136,9 @@ class Bmi_Model(Bmi_Minimal):
             int: grid identifier associated with @p name
         """
         if name in (self.input_names + self.output_names):
-            return 0 # should these be on a grid???
+            return 0  # should these be on a grid???
 
-        raise(UnknownBMIVariable(f"No known variable in BMI model: {name}"))
+        raise (UnknownBMIVariable(f"No known variable in BMI model: {name}"))
 
     def get_var_itemsize(self, name: str) -> int:
         """Size, in bytes, of a single element of the variable name

--- a/bmi_pytorch/bmi_pytorch/model.py
+++ b/bmi_pytorch/bmi_pytorch/model.py
@@ -10,6 +10,7 @@ Torch model for a multi-layer Neural Network with weights and bias
 """
 
 from math import sqrt
+
 # Typing imports
 from typing import Callable, List, Optional
 

--- a/bmi_pytorch/tests/conftest.py
+++ b/bmi_pytorch/tests/conftest.py
@@ -10,8 +10,9 @@ import torch
 from bmi_pytorch.bmi_model import Bmi_Model
 from bmi_pytorch.config import Config
 
-class TestDataDownloadError(Exception):
-    ...
+
+class TestDataDownloadError(Exception): ...
+
 
 def pytest_configure(config: pytest.Config) -> None:
     """Download CAMELS data if it doesn't already exist"""
@@ -34,6 +35,7 @@ def pytest_configure(config: pytest.Config) -> None:
 
     else:
         print(f"CAMELS data already exists in {data_path}")
+
 
 @pytest.fixture
 def input() -> torch.Tensor:

--- a/bmi_pytorch/tests/test_bmi_model.py
+++ b/bmi_pytorch/tests/test_bmi_model.py
@@ -8,11 +8,11 @@ from torch import Tensor, tensor, float16, float32, float64, int16, int32, int64
 def test_bmi_model_construct() -> None:
     """Tests the model default construction with no custom configuration
 
-       Currently tests input_names, output_names, and grid are "correct"
-       Also validates that input and output are not None
+    Currently tests input_names, output_names, and grid are "correct"
+    Also validates that input and output are not None
 
-       Additional tests of bmi/model states at construction can be
-       added here as the model is developed.
+    Additional tests of bmi/model states at construction can be
+    added here as the model is developed.
     """
 
     # Construct the model, 1 input, 1 output\
@@ -30,6 +30,7 @@ def test_bmi_model_construct() -> None:
 
     assert model.input != None
     assert model.output != None
+
 
 def test_bmi_initialize(config: Config, bmi_model) -> None:
     """Test bmi initialization function from config
@@ -53,17 +54,20 @@ def test_bmi_initialize(config: Config, bmi_model) -> None:
     assert bmi_model.learning_rate == config.learning_rate
     assert bmi_model.optimizer != None
 
-@pytest.mark.parametrize('model', ['bmi_model', 'bmi_model_initialized'])
+
+@pytest.mark.parametrize("model", ["bmi_model", "bmi_model_initialized"])
 def test_bmi_component_name(model, request):
     m = request.getfixturevalue(model)
     assert m.get_component_name() == "Tensor Test"
 
-@pytest.mark.parametrize('model', ['bmi_model', 'bmi_model_initialized'])
+
+@pytest.mark.parametrize("model", ["bmi_model", "bmi_model_initialized"])
 def test_bmi_input_item_count(model, request):
     m = request.getfixturevalue(model)
     assert m.get_input_item_count() == 1
 
-@pytest.mark.parametrize('model', ['bmi_model', 'bmi_model_initialized'])
+
+@pytest.mark.parametrize("model", ["bmi_model", "bmi_model_initialized"])
 def test_bmi_input_var_names(model, request):
     m = request.getfixturevalue(model)
     assert m.get_input_item_count() == 1
@@ -71,12 +75,14 @@ def test_bmi_input_var_names(model, request):
     assert len(names) == 1
     assert names[0] == "precipitation"
 
-@pytest.mark.parametrize('model', ['bmi_model', 'bmi_model_initialized'])
+
+@pytest.mark.parametrize("model", ["bmi_model", "bmi_model_initialized"])
 def test_bmi_output_item_count(model, request):
     m = request.getfixturevalue(model)
     assert m.get_output_item_count() == 1
 
-@pytest.mark.parametrize('model', ['bmi_model', 'bmi_model_initialized'])
+
+@pytest.mark.parametrize("model", ["bmi_model", "bmi_model_initialized"])
 def test_bmi_output_var_names(model, request):
     m = request.getfixturevalue(model)
     assert m.get_output_item_count() == 1
@@ -84,29 +90,32 @@ def test_bmi_output_var_names(model, request):
     assert len(names) == 1
     assert names[0] == "runoff"
 
-@pytest.mark.parametrize("var,expected", [
-                            ("precipitation", 0),
-                            ("runoff", 0)
-                        ])
+
+@pytest.mark.parametrize("var,expected", [("precipitation", 0), ("runoff", 0)])
 def test_bmi_var_grid(bmi_model_initialized, var, expected):
     m = bmi_model_initialized
     assert m.get_var_grid(var) == expected
+
 
 @pytest.mark.parametrize("var", ["var1", "var2"])
 def test_bmi_var_grid_2(bmi_model_initialized, var):
     m = bmi_model_initialized
     with pytest.raises(UnknownBMIVariable):
-            m.get_var_grid(var)
+        m.get_var_grid(var)
 
-@pytest.mark.parametrize("input", [
-                          Tensor([0,0]),
-                          Tensor([0, 1, 2]),
-                          Tensor([2, 1, 0]),
-                          Tensor([ [0] ]),
-                          Tensor([ [0, 1] ]),
-                          Tensor([ [0, 1], [2, 3] ]),
-                          Tensor([ [3, 2], [1, 0] ])
-                        ])
+
+@pytest.mark.parametrize(
+    "input",
+    [
+        Tensor([0, 0]),
+        Tensor([0, 1, 2]),
+        Tensor([2, 1, 0]),
+        Tensor([[0]]),
+        Tensor([[0, 1]]),
+        Tensor([[0, 1], [2, 3]]),
+        Tensor([[3, 2], [1, 0]]),
+    ],
+)
 def test_bmi_get_var_ptr(bmi_model_initialized, input):
     name = "precipitation"
     m = bmi_model_initialized
@@ -114,32 +123,37 @@ def test_bmi_get_var_ptr(bmi_model_initialized, input):
     m._values[name] = m.input
     data = m.get_value_ptr(name)
     # Can't test this since data is flattened...
-    #assert data.shape == m.input.shape
+    # assert data.shape == m.input.shape
     assert data.shape == m.input.flatten().shape
-    for expected, val in zip( m.input.flatten(), data.flatten() ):
+    for expected, val in zip(m.input.flatten(), data.flatten()):
         assert expected == val
+
 
 def test_bmi_get_var_ptr_1(bmi_model_initialized, input):
     name = "precipitation"
     expected = (4, 5, 6)
     m = bmi_model_initialized
-    m.input = Tensor([1,2,3])
+    m.input = Tensor([1, 2, 3])
     m._values[name] = m.input
     data = m.get_value_ptr(name)
     data[:] = expected[:]
-    
-    for expected, val in zip( m.input.flatten(), expected ):
+
+    for expected, val in zip(m.input.flatten(), expected):
         assert expected == val
 
-@pytest.mark.parametrize("input", [
-                          Tensor([0.0, 0]),
-                          Tensor([0, 1.0, 2]),
-                          Tensor([2, 1, 0]),
-                          Tensor([ [0] ]),
-                          Tensor([ [0, 1.0] ]),
-                          Tensor([ [0, 1.0], [2, 3.0] ]),
-                          Tensor([ [3, 2], [1.0, 0] ])
-                        ])
+
+@pytest.mark.parametrize(
+    "input",
+    [
+        Tensor([0.0, 0]),
+        Tensor([0, 1.0, 2]),
+        Tensor([2, 1, 0]),
+        Tensor([[0]]),
+        Tensor([[0, 1.0]]),
+        Tensor([[0, 1.0], [2, 3.0]]),
+        Tensor([[3, 2], [1.0, 0]]),
+    ],
+)
 def test_bmi_get_var_itemsize(bmi_model_initialized, input):
     name = "precipitation"
     m = bmi_model_initialized
@@ -149,15 +163,19 @@ def test_bmi_get_var_itemsize(bmi_model_initialized, input):
 
     assert input.itemsize == data
 
-@pytest.mark.parametrize("input", [
-                          Tensor([0.0, 0]),
-                          Tensor([0, 1.0, 2]),
-                          Tensor([2, 1, 0]),
-                          Tensor([ [0] ]),
-                          Tensor([ [0, 1.0] ]),
-                          Tensor([ [0, 1.0], [2, 3.0] ]),
-                          Tensor([ [3, 2], [1.0, 0] ])
-                        ])
+
+@pytest.mark.parametrize(
+    "input",
+    [
+        Tensor([0.0, 0]),
+        Tensor([0, 1.0, 2]),
+        Tensor([2, 1, 0]),
+        Tensor([[0]]),
+        Tensor([[0, 1.0]]),
+        Tensor([[0, 1.0], [2, 3.0]]),
+        Tensor([[3, 2], [1.0, 0]]),
+    ],
+)
 def test_bmi_get_var_nybtes(bmi_model_initialized, input):
     name = "precipitation"
     m = bmi_model_initialized
@@ -167,15 +185,19 @@ def test_bmi_get_var_nybtes(bmi_model_initialized, input):
 
     assert input.nbytes == data
 
-@pytest.mark.parametrize("input", [
-                          tensor([0, 0], dtype=int8),
-                          tensor([0, 1.0, 2], dtype=int16),
-                          tensor([2, 1, 0], dtype=int32),
-                          tensor([ [0] ], dtype=int64),
-                          tensor([ [0, 1.0] ], dtype=float16),
-                          tensor([ [0, 1.0], [2, 3.0] ], dtype=float32),
-                          tensor([ [3, 2], [1.0, 0] ], dtype=float64)
-                        ])
+
+@pytest.mark.parametrize(
+    "input",
+    [
+        tensor([0, 0], dtype=int8),
+        tensor([0, 1.0, 2], dtype=int16),
+        tensor([2, 1, 0], dtype=int32),
+        tensor([[0]], dtype=int64),
+        tensor([[0, 1.0]], dtype=float16),
+        tensor([[0, 1.0], [2, 3.0]], dtype=float32),
+        tensor([[3, 2], [1.0, 0]], dtype=float64),
+    ],
+)
 def test_bmi_get_var_type(bmi_model_initialized, input):
     name = "precipitation"
     m = bmi_model_initialized

--- a/bmi_pytorch/tests/test_model.py
+++ b/bmi_pytorch/tests/test_model.py
@@ -57,7 +57,7 @@ def test_data_load(data_dims: Tuple[int, int]):
         data_dims (_type_): _description_
     """
     # Load the data
-    runoff_mean, precip_mean = load_data(Path(__file__).parent/"data/CAMELS")
+    runoff_mean, precip_mean = load_data(Path(__file__).parent / "data/CAMELS")
     # Check the shapes and dtypes
     assert isinstance(runoff_mean, np.ndarray), "Runoff mean is not a numpy array"
     assert isinstance(precip_mean, np.ndarray), "Precip mean is not a numpy array"

--- a/bmi_sdk/bmi_sdk/bmi_minimal.py
+++ b/bmi_sdk/bmi_sdk/bmi_minimal.py
@@ -3,13 +3,14 @@ from bmipy import Bmi
 
 from typing import Tuple
 
+
 class Bmi_Minimal(Bmi):
     """Intermediate ABC for implementing functionality of standard BMI
        which isn't strictly needed for "functional" BMI.  This class
        simply implements the functions which raise NotImplementedError
 
        A not very useful, but fully functional BMI model likely only requires
-       
+
        initialize()
        update()
        finalize()
@@ -33,6 +34,7 @@ class Bmi_Minimal(Bmi):
     Args:
         Bmi (Bmi): Base BMI abstract class
     """
+
     #############
     # Bmi functions which have a reasonable "default" implementation
     #############
@@ -52,7 +54,7 @@ class Bmi_Minimal(Bmi):
 
     def get_value(self, name: str, dest: ndarray) -> ndarray:
         dest[:] = self.get_value_ptr(name)
-    
+
     def get_var_nbytes(self, name: str) -> int:
         """Get the number of total bytes required to represent the variable.
 
@@ -66,7 +68,7 @@ class Bmi_Minimal(Bmi):
 
     def get_var_type(self, name: str) -> str:
         """Data type of the variable.
-        
+
            If the variable is an array, this is the type of a single
            element of the array.
 
@@ -98,7 +100,7 @@ class Bmi_Minimal(Bmi):
             int: number of input variables
         """
         raise NotImplementedError()
-    
+
     def get_input_var_names(self) -> Tuple[str]:
         """The names of each input variables
 
@@ -114,7 +116,7 @@ class Bmi_Minimal(Bmi):
             int: number of output variables
         """
         raise NotImplementedError()
-    
+
     def get_output_var_names(self) -> Tuple[str]:
         """The names of each output variable
 
@@ -137,7 +139,7 @@ class Bmi_Minimal(Bmi):
             int: grid identifier associated with @p name
         """
         raise NotImplementedError()
-    
+
     def get_var_itemsize(self, name: str) -> int:
         """Size, in bytes, of a single element of the variable name
 
@@ -148,13 +150,13 @@ class Bmi_Minimal(Bmi):
             int: number of bytes representing a single variable of @p name
         """
         raise NotImplementedError()
-    
+
     def get_var_location(self, name: str) -> str:
         """Location of the variable relative to the grid
 
         Args:
             name (str): name of the BMI variable
-        
+
         Raises:
             UnknownBMIVariable: name is not recognized, location unknown
 
@@ -162,7 +164,7 @@ class Bmi_Minimal(Bmi):
             str: location on the grid, e.g. node, face
         """
         raise NotImplementedError()
-    
+
     def get_var_units(self, name: str) -> str:
         """Get units of the given variable
 
@@ -179,86 +181,86 @@ class Bmi_Minimal(Bmi):
 
     def get_var_grid(self, name: str) -> int:
         raise NotImplementedError()
-    
+
     def get_var_location(self, name: str) -> str:
         raise NotImplementedError()
-    
+
     def get_var_units(self, name: str) -> str:
         raise NotImplementedError()
 
     def get_current_time(self) -> float:
         raise NotImplementedError()
-    
+
     def get_end_time(self) -> float:
         raise NotImplementedError()
-    
+
     # BMI grid functions
     def get_grid_edge_count(self, grid: int) -> int:
         raise NotImplementedError()
-    
+
     def get_grid_edge_nodes(self, grid: int, edge_nodes: ndarray) -> ndarray:
         raise NotImplementedError()
-    
+
     def get_grid_face_count(self, grid: int) -> int:
         raise NotImplementedError()
-    
+
     def get_grid_face_edges(self, grid: int, face_edges: ndarray) -> ndarray:
         raise NotImplementedError()
-    
+
     def get_grid_face_nodes(self, grid: int, face_nodes: ndarray) -> ndarray:
         raise NotImplementedError()
-    
+
     def get_grid_node_count(self, grid: int) -> int:
         raise NotImplementedError()
-    
+
     def get_grid_nodes_per_face(self, grid: int, nodes_per_face: ndarray) -> ndarray:
         raise NotImplementedError()
-    
+
     def get_grid_origin(self, grid: int, origin: ndarray) -> ndarray:
         raise NotImplementedError()
-    
+
     def get_grid_rank(self, grid: int) -> int:
         raise NotImplementedError()
-    
+
     def get_grid_shape(self, grid: int, shape: ndarray) -> ndarray:
         raise NotImplementedError()
-    
+
     def get_grid_size(self, grid: int) -> int:
         raise NotImplementedError()
-    
+
     def get_grid_spacing(self, grid: int, spacing: ndarray) -> ndarray:
         raise NotImplementedError()
-    
+
     def get_grid_type(self, grid: int) -> str:
         raise NotImplementedError()
-    
+
     def get_grid_x(self, grid: int, x: ndarray) -> ndarray:
         raise NotImplementedError()
-    
+
     def get_grid_y(self, grid: int, y: ndarray) -> ndarray:
         raise NotImplementedError()
-    
+
     def get_grid_z(self, grid: int, z: ndarray) -> ndarray:
         raise NotImplementedError()
-        
+
     def get_start_time(self) -> float:
         raise NotImplementedError()
-    
+
     def get_time_step(self) -> float:
         raise NotImplementedError()
-    
+
     def get_time_units(self) -> str:
         raise NotImplementedError()
-    
+
     # BMI get/set
     def get_value_ptr(self, name: str) -> ndarray:
         raise NotImplementedError
 
     def get_value_at_indices(self, name: str, dest: ndarray, inds: ndarray) -> ndarray:
         raise NotImplementedError()
-    
+
     def set_value(self, name: str, src: ndarray) -> None:
         raise NotImplementedError()
-    
+
     def set_value_at_indices(self, name: str, inds: ndarray, src: ndarray) -> None:
         raise NotImplementedError()

--- a/bmi_sdk/bmi_sdk/bmi_time.py
+++ b/bmi_sdk/bmi_sdk/bmi_time.py
@@ -1,7 +1,28 @@
-from pydantic import BaseModel, Field, field_validator, ValidationInfo
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+TimeUnits = Literal[
+    "s",
+    "sec",
+    "second",
+    "seconds",
+    "min",
+    "minute",
+    "minutes",
+    "h",
+    "hr",
+    "hour",
+    "hours",
+    "d",
+    "day",
+    "days",
+]
+
 
 class BmiTime(BaseModel):
-    """Time components required for BMI.
+    """
+    Time components required for BMI.
 
     BMI doesn't have much for specific time implementaiton, but some hints can be found
     in the time funciton docs: https://bmi.readthedocs.io/en/stable/#time-functions
@@ -11,35 +32,13 @@ class BmiTime(BaseModel):
     "The start time in BMI is typically defined to be 0.0."
     "If the model doesn’t define an end time, a large number (e.g., the largest floating point number supported on a platform) is typically chosen."
     "A time step is typically a positive value. However, if the model permits it, a negative value can be used (running the model backward)."
-
     """
-    current_time: float = Field(default=0)
-    start_time: float = Field(default=0)
-    end_time: float = Field(default=float('inf'))
-    units: str = Field(default="s")
-    time_step: float = Field(default=3600)
 
-    @field_validator('units')
-    @classmethod
-    def check_time_units(cls, v: str, info: ValidationInfo) -> str:
-        """_summary_
-
-        Args:
-            v (str): unit string to check
-            info (ValidationInfo): Context for the class being validated.
-
-        Returns:
-            str: valid udunits2 time unit string
-        """
-        # TODO extracted from looking throug the xml files
-        # https://docs.unidata.ucar.edu/udunits/current/#Database
-        # need to verify this is a complete set...
-        valid_units = ["s", "sec", "second", "seconds", 
-                       "min", "minute", "minutes"
-                       "h", "hr", "hour", "hours", 
-                       "d", "day", "days"]
-        if(not v in valid_units):
-            raise ValueError(f'{info.field_name} must be one of {valid_units}')
-        # could use assert here, but it will be disabled if python is run with optimization (-O) flag
-        # assert v in valid_units, f'{info.field_name} must be one of {valid_units}'
-        return v
+    current_time: float = Field(default=0.0)
+    start_time: float = Field(default=0.0)
+    end_time: float = Field(default=float("inf"))
+    # TODO: extracted from looking through the xml files
+    # https://docs.unidata.ucar.edu/udunits/current/#Database
+    # need to verify this is a complete set...
+    units: TimeUnits = Field(default="s")
+    time_step: float = Field(default=3600.0)

--- a/bmi_sdk/bmi_sdk/bmi_time.py
+++ b/bmi_sdk/bmi_sdk/bmi_time.py
@@ -1,0 +1,45 @@
+from pydantic import BaseModel, Field, field_validator, ValidationInfo
+
+class BmiTime(BaseModel):
+    """Time components required for BMI.
+
+    BMI doesn't have much for specific time implementaiton, but some hints can be found
+    in the time funciton docs: https://bmi.readthedocs.io/en/stable/#time-functions
+
+    e.g.
+    "Model time is always expressed as a floating point value."
+    "The start time in BMI is typically defined to be 0.0."
+    "If the model doesn’t define an end time, a large number (e.g., the largest floating point number supported on a platform) is typically chosen."
+    "A time step is typically a positive value. However, if the model permits it, a negative value can be used (running the model backward)."
+
+    """
+    current_time: float = Field(default=0)
+    start_time: float = Field(default=0)
+    end_time: float = Field(default=float('inf'))
+    units: str = Field(default="s")
+    time_step: float = Field(default=3600)
+
+    @field_validator('units')
+    @classmethod
+    def check_time_units(cls, v: str, info: ValidationInfo) -> str:
+        """_summary_
+
+        Args:
+            v (str): unit string to check
+            info (ValidationInfo): Context for the class being validated.
+
+        Returns:
+            str: valid udunits2 time unit string
+        """
+        # TODO extracted from looking throug the xml files
+        # https://docs.unidata.ucar.edu/udunits/current/#Database
+        # need to verify this is a complete set...
+        valid_units = ["s", "sec", "second", "seconds", 
+                       "min", "minute", "minutes"
+                       "h", "hr", "hour", "hours", 
+                       "d", "day", "days"]
+        if(not v in valid_units):
+            raise ValueError(f'{info.field_name} must be one of {valid_units}')
+        # could use assert here, but it will be disabled if python is run with optimization (-O) flag
+        # assert v in valid_units, f'{info.field_name} must be one of {valid_units}'
+        return v

--- a/bmi_sdk/tests/test_bmi_time.py
+++ b/bmi_sdk/tests/test_bmi_time.py
@@ -1,11 +1,28 @@
-from ..bmi_time import BmiTime
-from pydantic import ValidationError
 import pytest
+from pydantic import ValidationError
 
-@pytest.mark.parametrize('unit', ["s", "sec", "second", "seconds", 
-                       "min", "minute", "minutes"
-                       "h", "hr", "hour", "hours", 
-                       "d", "day", "days"])
+from ..bmi_time import BmiTime
+
+
+@pytest.mark.parametrize(
+    "unit",
+    [
+        "s",
+        "sec",
+        "second",
+        "seconds",
+        "min",
+        "minute",
+        "minutes",
+        "h",
+        "hr",
+        "hour",
+        "hours",
+        "d",
+        "day",
+        "days",
+    ],
+)
 def test_good_time_units(unit: str) -> None:
     """Test validation of time units
 
@@ -15,10 +32,10 @@ def test_good_time_units(unit: str) -> None:
     t = BmiTime(units=unit)
     assert t.units == unit
 
-@pytest.mark.parametrize('unit', ["secs", "summer", 
-                       "mins", "minut",
-                       "hrs", "huors", 
-                       "year", "years"])
+
+@pytest.mark.parametrize(
+    "unit", ["secs", "summer", "mins", "minut", "hrs", "huors", "year", "years"]
+)
 def test_bad_time_units(unit: str) -> None:
     """Test validation of time units
 

--- a/bmi_sdk/tests/test_bmi_time.py
+++ b/bmi_sdk/tests/test_bmi_time.py
@@ -1,0 +1,29 @@
+from ..bmi_time import BmiTime
+from pydantic import ValidationError
+import pytest
+
+@pytest.mark.parametrize('unit', ["s", "sec", "second", "seconds", 
+                       "min", "minute", "minutes"
+                       "h", "hr", "hour", "hours", 
+                       "d", "day", "days"])
+def test_good_time_units(unit: str) -> None:
+    """Test validation of time units
+
+    Args:
+        unit (str): unit of time
+    """
+    t = BmiTime(units=unit)
+    assert t.units == unit
+
+@pytest.mark.parametrize('unit', ["secs", "summer", 
+                       "mins", "minut",
+                       "hrs", "huors", 
+                       "year", "years"])
+def test_bad_time_units(unit: str) -> None:
+    """Test validation of time units
+
+    Args:
+        unit (str): unit of time
+    """
+    with pytest.raises(ValidationError):
+        t = BmiTime(units=unit)


### PR DESCRIPTION
This model can be used in BMI implementations to store related time components and validate the BMI constraints of these meta data.