### PR TITLE
Create an sdk exception module and use it in the bmi model

### DIFF
--- a/bmi_pytorch/bmi_pytorch/bmi_model.py
+++ b/bmi_pytorch/bmi_pytorch/bmi_model.py
@@ -6,15 +6,11 @@ from bmi_sdk.bmi_minimal import Bmi_Minimal
 from torch import Tensor
 
 from bmi_sdk.bmi_grid import Grid, GridType
+from bmi_sdk import UnknownBMIVariable
 from .config import Config
 from .model import Model
 
 from typing import Tuple, List
-
-
-class UnknownBMIVariable(RuntimeError):
-    pass
-
 
 class Bmi_Model(Bmi_Minimal):
     """BMI composition wrapper for Model

--- a/bmi_sdk/bmi_sdk/__init__.py
+++ b/bmi_sdk/bmi_sdk/__init__.py
@@ -1,0 +1,1 @@
+from .exceptions import UnknownBMIVariable

--- a/bmi_sdk/bmi_sdk/exceptions.py
+++ b/bmi_sdk/bmi_sdk/exceptions.py
@@ -1,0 +1,2 @@
+class UnknownBMIVariable(RuntimeError):
+    pass


### PR DESCRIPTION
Move the `UnknownBMIVariable` custom exception into the sdk package and expose it to the package namespace for use with bmi models.