### PR TITLE
ci: add black pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,7 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
+  - repo: https://github.com/psf/black-pre-commit-mirror 
+    rev: 24.4.0
+    hooks:
+      - id: black

--- a/README.md
+++ b/README.md
@@ -31,7 +31,22 @@ pip install ./bmi_pytorch
 pip install ./bmi_sdk/
 ```
 
-### Running Tests
+### Local Development
+
+#### `pre-commit` hooks
+
+We use `pre-commit` hooks to run tasks like code formatting and linting.
+After cloning the repo and setting up a python virtual environment, install `pre-commit` with:
+
+```python
+pip install pre-commit
+```
+
+Next, run `pre-commit install` (you must from a directory in your repo clone).
+That's all!
+Now, whenever you make a commit, `pre-commit` will run hooks to ensure that your code is properly formatted and linted!
+
+#### Running Tests
 
 We use `pytest` to write and run our tests. Do the following to build and run tests:
 


### PR DESCRIPTION
Add black code formatter as a `pre-commit` hook. Once, #22 and  #23 have merged, I will set this up in CI. 